### PR TITLE
fix: use NPM_CONFIG_USERCONFIG env var for Artifactory auth

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,4 +37,6 @@ jobs:
           output-modes: npm
 
       - name: Publish to Artifactory npm-public
-        run: npm publish --userconfig=./.npmrc-public --@lexicographic:registry="https://packages.atlassian.com/api/npm/npm-public/"
+        run: npm publish
+        env:
+          NPM_CONFIG_USERCONFIG: ${{ github.workspace }}/.npmrc-public


### PR DESCRIPTION
Fixes 403 when publishing to Artifactory npm-public. Based on working examples from atlassian-labs/compiled, the correct approach is to set NPM_CONFIG_USERCONFIG env var rather than passing --userconfig as a CLI flag.